### PR TITLE
Use Typeable to get package name when necessary

### DIFF
--- a/lift-generics.cabal
+++ b/lift-generics.cabal
@@ -1,24 +1,29 @@
 name:                lift-generics
 version:             0.2
 synopsis:            GHC.Generics-based Language.Haskell.TH.Syntax.lift implementation
-description:         This package provides a "GHC.Generics"-based @genericLiftWithPkg@
-                     function (intended for GHC 7.10 and earlier), as well as a
-                     @genericLift@ function (only available on GHC 8.0 and later),
-                     both of which can be used for providing a
+description:         This package provides a "GHC.Generics"-based @genericLift@
+                     function (only available on GHC 7.4 and later), as well as
+                     a @genericLiftWithPkgFallback@ function (for code that
+                     must support GHC 7.2 and earlier) and a
+                     @genericLiftWithPkg@ function (for use when neither of the
+                     above will work), all of which can be used for providing a
                      @Language.Haskell.TH.Syntax.lift@ implementation. See the
-                     documentation in the "Language.Haskell.TH.Lift.Generics" module
-                     to get started.
+                     documentation in the "Language.Haskell.TH.Lift.Generics"
+                     module to get started.
                      .
                      Credit goes to Matthew Pickering for
                      <https://ghc.haskell.org/trac/ghc/ticket/1830#comment:12 suggesting this idea>.
                      .
-                     Note that due to API limitations, "GHC.Generics" wasn't powerful
-                     enough to come up with the entirety of a `lift` implementation prior
-                     to GHC 8.0. For this reason, @genericLiftWithPkg@ requires you to
-                     produce the package name yourself, which proves to be no small feat
-                     (see the documentation for more info).
+                     Note that due to API limitations, "GHC.Generics" wasn't
+                     powerful enough to come up with the entirety of a `lift`
+                     implementation prior to GHC 8.0. For GHC 7.4 and later, we
+                     can pluck this information out of `Typeable`. For earlier
+                     versions, and where `Typeable` isn't available,
+                     @genericLiftWithPkg@ requires you to produce the package
+                     name yourself, which proves to be no small feat (see the
+                     documentation for more info).
                      .
-                     Luckily, you don't have to jump through as many hoops on GHC 8.0 and
+                     Luckily, you don't have to jump through as many hoops on GHC 7.4 and
                      later: simply use the @genericLift@ function, and life is good.
 homepage:            https://github.com/RyanGlScott/lift-generics
 bug-reports:         https://github.com/RyanGlScott/lift-generics/issues


### PR DESCRIPTION
It's been possible to get the package name from a `TypeRep`
since `base-4.5`, though it only became possible to get one
from a `Generic` representation in `base-4.9.0`. Extend the
convenient/easy functions back to `base-4.5`, adding an extra
`Typeable` constraint where needed.

Closes #4.