### PR TITLE
Don't require fully monomorphic/overly Typeable constrained instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.2.1 [2021.09.??]
+* The lifting functions have been modified to reduce splice
+  time for constructors with many fields from quadratic to
+  linear. This probably only has a modest impact on total
+  compilation time.
+
+* `genericLift`, `genericLiftTyped`, `genericLiftTypedExp`, and
+  `genericLiftTypedCompat` functions now work for GHC 7.4 and above
+  for types that derive `Typeable`.
+
+* `genericLiftWithPkgFallback`, `genericLiftTypedWithPkgFallback`,
+  `genericLiftTypedExpWithPkgFallback`, and
+  `genericLiftTypedCompatWithPkgFallback` functions have been added that take
+  advantage of `Typeable` instances for GHC 7.4 and above but also take a
+  user-provided package name for earlier versions.
+
 ## 0.2 [2020.09.30]
 * `genericLiftTyped` and `genericLiftTypedWithPkg` now return a `Code` instead
   of a `TExp` to reflect the type of `liftTyped` changing in

--- a/lift-generics.cabal
+++ b/lift-generics.cabal
@@ -78,6 +78,8 @@ test-suite spec
                        Paths_lift_generics
   build-depends:       base             >= 4.3   && < 5
                      , base-compat      >= 0.8.2 && < 1
+                     , containers       >= 0.1 && < 0.7
+                     , th-lift-instances >= 0.1 && < 0.2
                      , generic-deriving >= 1.9   && < 2
                      , hspec            >= 2     && < 3
                      , lift-generics

--- a/lift-generics.cabal
+++ b/lift-generics.cabal
@@ -57,11 +57,15 @@ source-repository head
 
 library
   exposed-modules:     Language.Haskell.TH.Lift.Generics
+  if (impl(ghc >= 7.4) && impl(ghc < 8.0))
+    other-modules:       Language.Haskell.TH.Lift.Generics.Internal.OuterTypeable
   build-depends:       base             >= 4.3 && < 5
                      , generic-deriving >= 1.9 && < 2
                      , ghc-prim
                      , template-haskell >= 2.4 && < 2.18
                      , th-compat        >= 0.1 && < 0.2
+  if (impl(ghc >= 7.4) && impl(ghc < 7.8))
+    build-depends:     tagged >= 0.5 && < 0.9
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/src/Language/Haskell/TH/Lift/Generics.hs
+++ b/src/Language/Haskell/TH/Lift/Generics.hs
@@ -51,23 +51,17 @@ package to derive 'Lift' instances. If you choose to continue with this package:
 
 For relevant versions, the \"friendly\" and \"less friendly\" functions require
 the type to satisfy an @OuterTypeable@ constraint.  A type is @OuterTypable@ if
-its /type constructor/ is 'Typeable'. For example, @'Maybe' a@ is only
-'Typeable' if @a@ is 'Typeable', but it is always @OuterTypeable@.
+its /type constructor/ (applied to any /kind/ arguments/ is 'Typeable'. For
+example, @'Maybe' a@ is only 'Typeable' if @a@ is 'Typeable', but it is always
+@OuterTypeable@. For @'Control.Applicative.Const' a b@ to be 'OuterTypeable',
+the /kinds/ of @a@ and @b@ must be 'Typeable'.
 
-Before GHC 7.8, only the last seven arguments are fully
-supported by @OuterTypeable@. So given a type
-
-@
-data Foo a b c d e f g h i = ...
-  deriving ('Typeable')
-@
-
-@OuterTypeable (Foo a b c d e f g h i)@ requires that @a@
-and @b@ be 'Typeable', but the rest of the arguments need
-not be. In practice, this means that if you use these
-functions to write a 'Lift' instance for a type with more
-than seven parameters on GHC < 7.8, then you'll need
-'Typeable' constraints on the first few.
+Before GHC 7.8, 'Typeable' can only be derived for types with seven
+or fewer parameters, all of kind @*@. Types with more parameters that
+manually instantiate the now-defunct @Typeable7@ class should work,
+but there may be some loss of polymorphism in the first arguments.
+Types whose 'Typeable' instances can't be derived because of kind issues
+will not work with these GHC versions.
 -}
 module Language.Haskell.TH.Lift.Generics (
 #if MIN_VERSION_base(4,5,0)

--- a/src/Language/Haskell/TH/Lift/Generics.hs
+++ b/src/Language/Haskell/TH/Lift/Generics.hs
@@ -241,6 +241,8 @@ import Data.Proxy (Proxy (..))
 -- === Note
 --
 -- A @'Data.Typeable.Typeable' a@ instance is required for 7.4 <= GHC < 8.0 (4.5 <= @base@ < 4.9).
+--
+-- @since 0.2.1
 #if MIN_VERSION_base (4,9,0) || !MIN_VERSION_base (4,5,0)
 genericLiftWithPkgFallback :: (Quote m, Generic a, GLift (Rep a)) => String -> a -> m Exp
 #else
@@ -254,6 +256,8 @@ genericLiftWithPkgFallback = genericLiftWithPkg
 
 #if MIN_VERSION_template_haskell(2,9,0)
 -- | Like 'genericLiftWithPkgFallback', but returns a 'Code' instead of an 'Exp'.
+--
+-- @since 0.2.1
 # if MIN_VERSION_base (4,9,0) || !MIN_VERSION_base (4,5,0)
 genericLiftTypedWithPkgFallback :: (Quote m, Generic a, GLift (Rep a)) => String -> a -> Code m a
 # else
@@ -266,6 +270,8 @@ genericLiftTypedWithPkgFallback = genericLiftTypedWithPkg
 # endif
 
 -- | Like 'genericLiftWithPkgFallback', but returns a 'TExp' instead of an 'Exp'.
+--
+-- @since 0.2.1
 # if MIN_VERSION_base (4,9,0) || !MIN_VERSION_base (4,5,0)
 genericLiftTypedTExpWithPkgFallback :: (Quote m, Generic a, GLift (Rep a)) => String -> a -> m (TExp a)
 # else
@@ -284,6 +290,8 @@ genericLiftTypedTExpWithPkgFallback = genericLiftTypedTExpWithPkg
 --
 -- This function is ideal for implementing the 'liftTyped' method of 'Lift'
 -- directly, as its type changed in @template-haskell-2.17.0.0@.
+--
+-- @since 0.2.1
 # if MIN_VERSION_base (4,9,0) || !MIN_VERSION_base (4,5,0)
 genericLiftTypedCompatWithPkgFallback :: (Quote m, Generic a, GLift (Rep a)) => String -> a -> Splice m a
 # else

--- a/src/Language/Haskell/TH/Lift/Generics.hs
+++ b/src/Language/Haskell/TH/Lift/Generics.hs
@@ -51,7 +51,7 @@ package to derive 'Lift' instances. If you choose to continue with this package:
 
 For relevant versions, the \"friendly\" and \"less friendly\" functions require
 the type to satisfy an @OuterTypeable@ constraint.  A type is @OuterTypable@ if
-its /type constructor/ (applied to any /kind/ arguments/ is 'Typeable'. For
+its /type constructor/ (applied to any /kind/ arguments) is 'Typeable'. For
 example, @'Maybe' a@ is only 'Typeable' if @a@ is 'Typeable', but it is always
 @OuterTypeable@. For @'Control.Applicative.Const' a b@ to be 'OuterTypeable',
 the /kinds/ of @a@ and @b@ must be 'Typeable'.

--- a/src/Language/Haskell/TH/Lift/Generics.hs
+++ b/src/Language/Haskell/TH/Lift/Generics.hs
@@ -29,8 +29,8 @@ the built-in `DeriveLift` mechanism, which has the advantage of working for
 GADTs and existential types.
 
 * If you only need to support GHC 7.4 (@base@ 4.5) and later, and you have
-'Typeable' instances for the relevant types (or can derive them), then you should
-use the \"friendly\" functions here.
+'Typeable' instances for the relevant type constructors (or can derive them),
+then you should use the \"friendly\" functions here.
 
 * If you must support GHC versions before 7.4 (@base@ 4.5), or types in other
 packages without 'Typeable' instances, then you should seriously consider using
@@ -42,10 +42,32 @@ package to derive 'Lift' instances. If you choose to continue with this package:
     functions here. These take an argument for the package name, but they ignore it
     (acting just like the friendly ones) for GHC 7.4 (@base@ 4.5) and later.
 
-    * If you lack a 'Typeable' instance for a type, then you'll need to use the
-    \"unfriendly\" functions. These rely solely on the user-provided package
-    name. On GHC 7.10, it is extremely difficult to obtain the correct package
-    name for an external package.
+    * If you lack a 'Typeable' instance for a type constructor, then you'll
+    need to use the \"unfriendly\" functions. These rely solely on the
+    user-provided package name. On GHC 7.10, it is extremely difficult to
+    obtain the correct package name for an external package.
+
+=== A note on 'Typeable' constraints
+
+For relevant versions, the \"friendly\" and \"less friendly\" functions require
+the type to satisfy an @OuterTypeable@ constraint.  A type is @OuterTypable@ if
+its /type constructor/ is 'Typeable'. For example, @'Maybe' a@ is only
+'Typeable' if @a@ is 'Typeable', but it is always @OuterTypeable@.
+
+Before GHC 7.8, only the last seven arguments are fully
+supported by @OuterTypeable@. So given a type
+
+@
+data Foo a b c d e f g h i = ...
+  deriving ('Typeable')
+@
+
+@OuterTypeable (Foo a b c d e f g h i)@ requires that @a@
+and @b@ be 'Typeable', but the rest of the arguments need
+not be. In practice, this means that if you use these
+functions to write a 'Lift' instance for a type with more
+than seven parameters on GHC < 7.8, then you'll need
+'Typeable' constraints on the first few.
 -}
 module Language.Haskell.TH.Lift.Generics (
 #if MIN_VERSION_base(4,5,0)
@@ -78,14 +100,16 @@ module Language.Haskell.TH.Lift.Generics (
     , genericLiftTypedTExpWithPkgFallback
     , genericLiftTypedCompatWithPkgFallback
 #endif
-    
+
     -- ** Unfriendly implementations
     --
     -- | These implementations should be used when support for versions
     -- before GHC 8.0 (@base@ 4.9) is required and a 'Data.Typeable.Typeable' instance
     -- is /not/ available. These functions are termed "unfriendly" because
-    -- they probably won't work at all under GHC 7.10 when working with types
-    -- defined in other packages.
+    -- they're extremely hard to use under GHC 7.10 when working with types
+    -- defined in other packages. The only way to do so is to use a 'Typeable'
+    -- type in the same package to get the \"package name\", which will be a
+    -- hash value.
     , genericLiftWithPkg
 #if MIN_VERSION_template_haskell(2,9,0)
     , genericLiftTypedWithPkg
@@ -102,6 +126,10 @@ module Language.Haskell.TH.Lift.Generics (
     -- * 'Lift' reexport
     , Lift(..)
     ) where
+
+#if MIN_VERSION_base(4,5,0) && !MIN_VERSION_base(4,9,0)
+import Language.Haskell.TH.Lift.Generics.Internal.OuterTypeable
+#endif
 
 import Control.Monad (liftM, (>=>))
 
@@ -128,9 +156,9 @@ import GHC.Exts (Char(..))
 
 #if MIN_VERSION_base(4,5,0) && !MIN_VERSION_base(4,9,0)
 import qualified Data.Typeable as T
-import Data.Typeable (Typeable)
 #endif
-#if MIN_VERSION_base(4,7,0) && !MIN_VERSION_base(4,9,0)
+
+#if MIN_VERSION_base(4,5,0) && !MIN_VERSION_base(4,9,0)
 import Data.Proxy (Proxy (..))
 #endif
 
@@ -216,7 +244,7 @@ import Data.Proxy (Proxy (..))
 #if MIN_VERSION_base (4,9,0) || !MIN_VERSION_base (4,5,0)
 genericLiftWithPkgFallback :: (Quote m, Generic a, GLift (Rep a)) => String -> a -> m Exp
 #else
-genericLiftWithPkgFallback :: (Quote m, Generic a, GLift (Rep a), Typeable a) => String -> a -> m Exp
+genericLiftWithPkgFallback :: (Quote m, Generic a, GLift (Rep a), OuterTypeable a) => String -> a -> m Exp
 #endif
 #if MIN_VERSION_base(4,5,0)
 genericLiftWithPkgFallback _pkg = genericLift
@@ -229,7 +257,7 @@ genericLiftWithPkgFallback = genericLiftWithPkg
 # if MIN_VERSION_base (4,9,0) || !MIN_VERSION_base (4,5,0)
 genericLiftTypedWithPkgFallback :: (Quote m, Generic a, GLift (Rep a)) => String -> a -> Code m a
 # else
-genericLiftTypedWithPkgFallback :: (Quote m, Generic a, GLift (Rep a), Typeable a) => String -> a -> Code m a
+genericLiftTypedWithPkgFallback :: (Quote m, Generic a, GLift (Rep a), OuterTypeable a) => String -> a -> Code m a
 # endif
 # if MIN_VERSION_base(4,5,0)
 genericLiftTypedWithPkgFallback _pkg = genericLiftTyped
@@ -241,7 +269,7 @@ genericLiftTypedWithPkgFallback = genericLiftTypedWithPkg
 # if MIN_VERSION_base (4,9,0) || !MIN_VERSION_base (4,5,0)
 genericLiftTypedTExpWithPkgFallback :: (Quote m, Generic a, GLift (Rep a)) => String -> a -> m (TExp a)
 # else
-genericLiftTypedTExpWithPkgFallback :: (Quote m, Generic a, GLift (Rep a), Typeable a) => String -> a -> m (TExp a)
+genericLiftTypedTExpWithPkgFallback :: (Quote m, Generic a, GLift (Rep a), OuterTypeable a) => String -> a -> m (TExp a)
 # endif
 # if MIN_VERSION_base(4,5,0)
 genericLiftTypedTExpWithPkgFallback _pkg = genericLiftTypedTExp
@@ -259,7 +287,7 @@ genericLiftTypedTExpWithPkgFallback = genericLiftTypedTExpWithPkg
 # if MIN_VERSION_base (4,9,0) || !MIN_VERSION_base (4,5,0)
 genericLiftTypedCompatWithPkgFallback :: (Quote m, Generic a, GLift (Rep a)) => String -> a -> Splice m a
 # else
-genericLiftTypedCompatWithPkgFallback :: (Quote m, Generic a, GLift (Rep a), Typeable a) => String -> a -> Splice m a
+genericLiftTypedCompatWithPkgFallback :: (Quote m, Generic a, GLift (Rep a), OuterTypeable a) => String -> a -> Splice m a
 # endif
 # if MIN_VERSION_template_haskell(2,17,0)
 genericLiftTypedCompatWithPkgFallback = genericLiftTypedWithPkgFallback
@@ -347,20 +375,13 @@ genericLiftTypedCompatWithPkg = genericLiftTypedTExpWithPkg
 -- === Note
 --
 -- A @'Data.Typeable.Typeable' a@ instance is required for GHC < 8.0 (@base@ < 4.9).
-# if MIN_VERSION_base (4,7,0)
-#  if MIN_VERSION_base (4,9,0)
+# if MIN_VERSION_base (4,9,0)
 genericLift :: (Quote m, Generic a, GLift (Rep a)) => a -> m Exp
 genericLift = glift "" . from
-#  else
-genericLift :: forall m a. (Quote m, Generic a, GLift (Rep a), Typeable a) => a -> m Exp
-genericLift =
-  glift (T.tyConPackage (T.typeRepTyCon (T.typeRep (Proxy :: Proxy a))))
-    . from
-#  endif
 # else
-genericLift :: forall m a. (Quote m, Generic a, Typeable a, GLift (Rep a)) => a -> m Exp
+genericLift :: forall m a. (Quote m, Generic a, GLift (Rep a), OuterTypeable a) => a -> m Exp
 genericLift =
-  glift (T.tyConPackage (T.typeRepTyCon (T.typeOf (undefined :: a))))
+  glift (T.tyConPackage (T.typeRepTyCon (getConTR (Proxy :: Proxy a))))
     . from
 # endif
 
@@ -369,7 +390,7 @@ genericLift =
 #  if MIN_VERSION_base (4,9,0)
 genericLiftTyped :: (Quote m, Generic a, GLift (Rep a)) => a -> Code m a
 #  else
-genericLiftTyped :: (Quote m, Generic a, GLift (Rep a), Typeable a) => a -> Code m a
+genericLiftTyped :: (Quote m, Generic a, GLift (Rep a), OuterTypeable a) => a -> Code m a
 #  endif
 genericLiftTyped = unsafeCodeCoerce . genericLift
 
@@ -377,7 +398,7 @@ genericLiftTyped = unsafeCodeCoerce . genericLift
 #  if MIN_VERSION_base (4,9,0)
 genericLiftTypedTExp :: (Quote m, Generic a, GLift (Rep a)) => a -> m (TExp a)
 #  else
-genericLiftTypedTExp :: (Quote m, Generic a, GLift (Rep a), Typeable a) => a -> m (TExp a)
+genericLiftTypedTExp :: (Quote m, Generic a, GLift (Rep a), OuterTypeable a) => a -> m (TExp a)
 #  endif
 genericLiftTypedTExp = unsafeTExpCoerceQuote . genericLift
 
@@ -391,7 +412,7 @@ genericLiftTypedTExp = unsafeTExpCoerceQuote . genericLift
 #  if MIN_VERSION_base (4,9,0)
 genericLiftTypedCompat :: (Quote m, Generic a, GLift (Rep a)) => a -> Splice m a
 #  else
-genericLiftTypedCompat :: (Quote m, Generic a, GLift (Rep a), Typeable a) => a -> Splice m a
+genericLiftTypedCompat :: (Quote m, Generic a, GLift (Rep a), OuterTypeable a) => a -> Splice m a
 #  endif
 #  if MIN_VERSION_template_haskell(2,17,0)
 genericLiftTypedCompat = genericLiftTyped

--- a/src/Language/Haskell/TH/Lift/Generics/Internal/OuterTypeable.hs
+++ b/src/Language/Haskell/TH/Lift/Generics/Internal/OuterTypeable.hs
@@ -1,0 +1,85 @@
+{-# language CPP #-}
+{-# language FlexibleInstances #-}
+{-# language UndecidableInstances #-}
+{-# language ScopedTypeVariables #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# language PolyKinds #-}
+#endif
+
+#if __GLASGOW_HASKELL__ < 710
+{-# language OverlappingInstances #-}
+#endif
+
+module Language.Haskell.TH.Lift.Generics.Internal.OuterTypeable
+  ( OuterTypeable (..)
+  ) where
+import Data.Typeable
+
+-- | A type is @OuterTypable@ if its /type constructor/ is
+-- 'Typeable'. For example, @'Maybe' a@ is only 'Typeable' if
+-- @a@ is 'Typeable', but it is always @OuterTypeable@.
+--
+-- === Caution
+--
+-- Before GHC 7.8, only the last seven arguments are properly
+-- supported. So given a type
+--
+-- @
+-- data Foo a b c d e f g h i = ...
+--   deriving (Typeable)
+-- @
+--
+-- @OuterTypeable (Foo a b c d e f g h i)@ requires that @a@
+-- and @b@ be 'Typeable', but the rest of the arguments need
+-- not be.
+class OuterTypeable a where
+  -- | Get the 'TypeRep' corresponding to the outermost constructor
+  -- of a type.
+  getConTR :: proxy a -> TypeRep
+
+#if __GLASGOW_HASKELL__ >= 708
+
+# if __GLASGOW_HASKELL__ >= 710
+instance {-# OVERLAPPING #-} OuterTypeable f => OuterTypeable (f a) where
+# else
+instance                     OuterTypeable f => OuterTypeable (f a) where
+# endif
+  getConTR _ = getConTR (Proxy :: Proxy f)
+
+instance Typeable a => OuterTypeable a where
+  getConTR = typeRep
+
+-- Why do we need overlapping instances above? Couldn't we use
+-- the type family instance selection trick? No, we couldn't. We'd
+-- like to be able to write
+--
+-- type family IsApp (a :: k) :: Bool where
+--   IsApp (f a) = 'True
+--   IsApp a = 'False
+--
+-- and switch on that. Unfortunately, that type family wasn't allowed
+-- until TypeInType came out in GHC 8.0, which is precisely when we
+-- stop needing this module at all.
+
+#else
+
+-- Before GHC 7.8, we didn't have polykinded Typeable, so things were
+-- rather less pleasant.
+
+instance Typeable a => OuterTypeable a where
+  getConTR _ = typeOf (undefined :: a)
+instance Typeable1 p => OuterTypeable (p a) where
+  getConTR _ = typeOf1 (undefined :: p a)
+instance Typeable2 p => OuterTypeable (p a b) where
+  getConTR _ = typeOf2 (undefined :: p a b)
+instance Typeable3 p => OuterTypeable (p a b c) where
+  getConTR _ = typeOf3 (undefined :: p a b c)
+instance Typeable4 p => OuterTypeable (p a b c d) where
+  getConTR _ = typeOf4 (undefined :: p a b c d)
+instance Typeable5 p => OuterTypeable (p a b c d e) where
+  getConTR _ = typeOf5 (undefined :: p a b c d e)
+instance Typeable6 p => OuterTypeable (p a b c d e f) where
+  getConTR _ = typeOf6 (undefined :: p a b c d e f)
+instance Typeable7 p => OuterTypeable (p a b c d e f g) where
+  getConTR _ = typeOf7 (undefined :: p a b c d e f g)
+#endif

--- a/src/Language/Haskell/TH/Lift/Generics/Internal/OuterTypeable.hs
+++ b/src/Language/Haskell/TH/Lift/Generics/Internal/OuterTypeable.hs
@@ -15,23 +15,9 @@ module Language.Haskell.TH.Lift.Generics.Internal.OuterTypeable
   ) where
 import Data.Typeable
 
--- | A type is @OuterTypable@ if its /type constructor/ is
--- 'Typeable'. For example, @'Maybe' a@ is only 'Typeable' if
--- @a@ is 'Typeable', but it is always @OuterTypeable@.
---
--- === Caution
---
--- Before GHC 7.8, only the last seven arguments are properly
--- supported. So given a type
---
--- @
--- data Foo a b c d e f g h i = ...
---   deriving (Typeable)
--- @
---
--- @OuterTypeable (Foo a b c d e f g h i)@ requires that @a@
--- and @b@ be 'Typeable', but the rest of the arguments need
--- not be.
+-- | A type is @OuterTypable@ if its /type constructor/ (applied to any kind
+-- arguments) is 'Typeable'. For example, @'Maybe' a@ is only 'Typeable' if @a@
+-- is 'Typeable', but it is always @OuterTypeable@.
 class OuterTypeable a where
   -- | Get the 'TypeRep' corresponding to the outermost constructor
   -- of a type.

--- a/tests/LiftGenericsSpec.hs
+++ b/tests/LiftGenericsSpec.hs
@@ -12,8 +12,15 @@ Maintainer:  Ryan Scott
 -}
 module LiftGenericsSpec (main, spec) where
 
+import Instances.TH.Lift ()
 import Language.Haskell.TH.Syntax hiding (newName)
 import Language.Haskell.TH.Syntax.Compat
+#if MIN_VERSION_base(4,5,0)
+import Language.Haskell.TH.Lift.Generics (genericLift)
+# if MIN_VERSION_template_haskell(2,16,0)
+import Language.Haskell.TH.Lift.Generics (genericLiftTypedCompat)
+# endif
+#endif
 import Test.Hspec
 import Types
 import Control.Exception (Exception, throw, evaluate)
@@ -52,7 +59,39 @@ spec = parallel $ do
         describe "Ap" $
             it description $
                 z `shouldBe` $(lift z)
-#if MIN_VERSION_template_haskell(2,16,0)
+#if MIN_VERSION_base(4,5,0)
+        -- We use Tree to check that things work for types imported
+        -- from external packages without special distinguished names.
+        -- It proved rather tricky to find a good choice. This one's
+        -- not really ideal (I'd rather have a non-recursive type), but
+        -- it'll do for now.
+        describe "Tree" $
+            it description $
+                w `shouldBe` $(genericLift w)
+        describe "Unit'" $ do
+            it description $ do
+                Unit' `shouldBe` $(lift Unit')
+                ConE 'Unit' `shouldBe` runPureQ (liftQuote Unit')
+            it "should throw an exception on undefined" $
+                evaluate (runPureQ $ liftQuote (throw Exc :: Unit')) `shouldThrow` (== Exc)
+        describe "Product'" $
+            it description $
+                p' `shouldBe` $(lift p')
+        describe "Sum'" $
+            it description $
+                s' `shouldBe` $(lift s')
+        describe "Unboxed'" $
+            it description $
+                u' `shouldBe` $(lift u')
+        describe "Const'" $
+            it description $
+                c' `shouldBe` $(lift c')
+# if __GLASGOW_HASKELL__ >= 708
+        describe "Ap'" $
+            it description $
+                z' `shouldBe` $(lift z')
+#endif
+# if MIN_VERSION_template_haskell(2,16,0)
     describe "genericLiftTyped" $ do
         describe "Unit" $
             it description $ do
@@ -73,4 +112,8 @@ spec = parallel $ do
         describe "Ap" $
             it description $
                 z `shouldBe` $$(liftTyped z)
+        describe "Tree" $
+            it description $
+                w `shouldBe` $$(genericLiftTypedCompat w)
+# endif
 #endif

--- a/tests/LiftGenericsSpec.hs
+++ b/tests/LiftGenericsSpec.hs
@@ -46,6 +46,12 @@ spec = parallel $ do
         describe "Unboxed" $
             it description $
                 u `shouldBe` $(lift u)
+        describe "Const" $
+            it description $
+                c `shouldBe` $(lift c)
+        describe "Ap" $
+            it description $
+                z `shouldBe` $(lift z)
 #if MIN_VERSION_template_haskell(2,16,0)
     describe "genericLiftTyped" $ do
         describe "Unit" $
@@ -61,4 +67,10 @@ spec = parallel $ do
         describe "Unboxed" $
             it description $
                 u `shouldBe` $$(liftTyped u)
+        describe "Const" $
+            it description $
+                c `shouldBe` $$(liftTyped c)
+        describe "Ap" $
+            it description $
+                z `shouldBe` $$(liftTyped z)
 #endif

--- a/tests/Types.hs
+++ b/tests/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash                  #-}
@@ -8,6 +9,10 @@
 
 #if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE DataKinds                  #-}
+#endif
+
+#if !MIN_VERSION_containers(0,5,8)
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 #endif
 
 {-|
@@ -20,10 +25,26 @@ Data types for testing `lift-generics`' capabilities.
 -}
 module Types (
     PureQ, runPureQ
-  , Unit(..), Product(..), Sum(..)
-  , Const(..), Ap(..)
-  , p, s, u, c, z
+  , Unit(..)
+  , Product(..)
+  , Sum(..)
+  , Const(..)
+  , Ap(..)
+  , p, s, u, c, z, w
+#if MIN_VERSION_base(4,5,0)
+  , Unit'(..)
+  , Product'(..)
+  , Sum'(..)
+  , Const'(..)
+  , Ap'(..)
+  , p', s', u', c', z'
+#endif
   ) where
+
+import Data.Tree (Tree (..))
+#if MIN_VERSION_base(4,5,0)
+import Data.Typeable (Typeable)
+#endif
 
 import Control.Monad.State
 
@@ -31,11 +52,16 @@ import Generics.Deriving.TH (deriveAll)
 
 import GHC.Exts
 
-import Language.Haskell.TH.Lift.Generics ( genericLiftWithPkg
-#if MIN_VERSION_template_haskell(2,16,0)
-                                         , genericLiftTypedCompat
+import Language.Haskell.TH.Lift.Generics
+  ( genericLiftWithPkg
+#if MIN_VERSION_base(4,5,0)
+  , genericLift
 #endif
-                                         )
+#if MIN_VERSION_template_haskell(2,16,0)
+  , genericLiftTypedCompatWithPkg
+  , genericLiftTypedCompat
+#endif
+  )
 import Language.Haskell.TH.Syntax hiding (newName)
 import Language.Haskell.TH.Syntax.Compat
 
@@ -50,6 +76,10 @@ runPureQ m = case m of MkPureQ m' -> evalState m' 0
 
 instance Quote PureQ where
   newName s = state $ \i -> (mkNameU s i, i + 1)
+
+#if !MIN_VERSION_containers(0,5,8)
+$(deriveAll ''Tree)
+#endif
 
 data Unit = Unit
   deriving (Eq, Ord, Show)
@@ -105,31 +135,93 @@ c = Const 1
 z :: Ap Maybe Int
 z = Ap (Just 3)
 
+w :: Tree Int
+w = Node 3 [Node 4 [], Node 5 []]
+
+#if MIN_VERSION_base(4,5,0)
+data Unit' = Unit'
+  deriving (Eq, Ord, Show, Typeable)
+$(deriveAll ''Unit')
+
+data Product' a b c d = Product' a b c d
+  deriving (Eq, Ord, Show, Typeable)
+$(deriveAll ''Product')
+
+data Sum' a b = Inl' a | Inr' b
+  deriving (Eq, Ord, Show, Typeable)
+$(deriveAll ''Sum')
+
+newtype Const' a b = Const' a
+  deriving (Eq, Ord, Show, Typeable)
+$(deriveAll ''Const')
+
+newtype Ap' f a = Ap' (f a)
+  deriving (Eq, Ord, Show)
+#if __GLASGOW_HASKELL__ >= 708
+deriving instance Typeable Ap'
+#endif
+$(deriveAll ''Ap')
+
+data Unboxed' a
+   = Unboxed' a
+# if MIN_VERSION_template_haskell(2,11,0)
+             Char#
+# endif
+             Double#
+             Float#
+             Int#
+             Word#
+  deriving (Eq, Ord, Show, Typeable)
+$(deriveAll ''Unboxed')
+
+p' :: Product' Char Int Bool String
+p' = Product' 'a' 1 True "b"
+
+s' :: Sum Char Int
+s' = Inl 'c'
+
+u' :: Unboxed' Int
+u' = Unboxed' 1
+# if MIN_VERSION_template_haskell(2,11,0)
+            '1'#
+# endif
+            1.0##
+            1.0#
+            1#
+            1##
+
+c' :: Const' Int a
+c' = Const' 1
+
+z' :: Ap' Maybe Int
+z' = Ap' (Just 3)
+#endif
+
 pkgKey :: String
 pkgKey = "main"
 
 instance Lift Unit where
     lift = genericLiftWithPkg pkgKey
 #if MIN_VERSION_template_haskell(2,16,0)
-    liftTyped = genericLiftTypedCompat
+    liftTyped = genericLiftTypedCompatWithPkg pkgKey
 #endif
 
 instance (Lift a, Lift b, Lift c, Lift d) => Lift (Product a b c d) where
     lift = genericLiftWithPkg pkgKey
 #if MIN_VERSION_template_haskell(2,16,0)
-    liftTyped = genericLiftTypedCompat
+    liftTyped = genericLiftTypedCompatWithPkg pkgKey
 #endif
 
 instance (Lift a, Lift b) => Lift (Sum a b) where
     lift = genericLiftWithPkg pkgKey
 #if MIN_VERSION_template_haskell(2,16,0)
-    liftTyped = genericLiftTypedCompat
+    liftTyped = genericLiftTypedCompatWithPkg pkgKey
 #endif
 
 instance Lift a => Lift (Unboxed a) where
     lift = genericLiftWithPkg pkgKey
 #if MIN_VERSION_template_haskell(2,16,0)
-    liftTyped = genericLiftTypedCompat
+    liftTyped = genericLiftTypedCompatWithPkg pkgKey
 #endif
 
 -- This instance shows that we can have parametric polymorphism—we don't need
@@ -137,13 +229,56 @@ instance Lift a => Lift (Unboxed a) where
 instance Lift a => Lift (Const a b) where
     lift = genericLiftWithPkg pkgKey
 #if MIN_VERSION_template_haskell(2,16,0)
-    liftTyped = genericLiftTypedCompat
+    liftTyped = genericLiftTypedCompatWithPkg pkgKey
 #endif
 
--- This instance demonstrates some polykindedness—the arguments to Ap aren't
--- all of kind Type.
 instance Lift (f a) => Lift (Ap f a) where
     lift = genericLiftWithPkg pkgKey
 #if MIN_VERSION_template_haskell(2,16,0)
+    liftTyped = genericLiftTypedCompatWithPkg pkgKey
+#endif
+
+#if MIN_VERSION_base(4,5,0)
+
+instance Lift Unit' where
+    lift = genericLift
+# if MIN_VERSION_template_haskell(2,16,0)
     liftTyped = genericLiftTypedCompat
+# endif
+
+instance (Lift a, Lift b, Lift c, Lift d) => Lift (Product' a b c d) where
+    lift = genericLift
+# if MIN_VERSION_template_haskell(2,16,0)
+    liftTyped = genericLiftTypedCompat
+# endif
+
+instance (Lift a, Lift b) => Lift (Sum' a b) where
+    lift = genericLift
+# if MIN_VERSION_template_haskell(2,16,0)
+    liftTyped = genericLiftTypedCompat
+# endif
+
+instance Lift a => Lift (Unboxed' a) where
+    lift = genericLift
+# if MIN_VERSION_template_haskell(2,16,0)
+    liftTyped = genericLiftTypedCompat
+# endif
+
+-- This instance shows that we can have parametric polymorphism—we don't need
+-- Typeable instances for @a@ or @b@.
+instance Lift a => Lift (Const' a b) where
+    lift = genericLift
+# if MIN_VERSION_template_haskell(2,16,0)
+    liftTyped = genericLiftTypedCompat
+# endif
+
+# if __GLASGOW_HASKELL__ >= 708
+-- This instance demonstrates some polykindedness—the arguments to Ap' aren't
+-- all of kind Type. This only works for GHC 7.8 and later.
+instance Lift (f a) => Lift (Ap' f a) where
+    lift = genericLift
+#  if MIN_VERSION_template_haskell(2,16,0)
+    liftTyped = genericLiftTypedCompat
+#  endif
+# endif
 #endif

--- a/tests/Types.hs
+++ b/tests/Types.hs
@@ -139,6 +139,11 @@ w :: Tree Int
 w = Node 3 [Node 4 [], Node 5 []]
 
 #if MIN_VERSION_base(4,5,0)
+
+-- The types below are essentially the same as the ones above.  However, we
+-- give them genericLift-based instances rather than genericLiftWithPkg ones,
+-- to ensure that the former work too.
+
 data Unit' = Unit'
   deriving (Eq, Ord, Show, Typeable)
 $(deriveAll ''Unit')
@@ -224,8 +229,6 @@ instance Lift a => Lift (Unboxed a) where
     liftTyped = genericLiftTypedCompatWithPkg pkgKey
 #endif
 
--- This instance shows that we can have parametric polymorphism—we don't need
--- Typeable instances for @a@ or @b@.
 instance Lift a => Lift (Const a b) where
     lift = genericLiftWithPkg pkgKey
 #if MIN_VERSION_template_haskell(2,16,0)


### PR DESCRIPTION
`Typeable a` is much more than we need, and is a pain for things
like a `Const x y` instance. We only need a `TypeRep` for the
*type constructor* of `a`. We can do this very nicely with
polykinded `Typeable`, and more painfully before that.

Fixes #8